### PR TITLE
adds Percentage#to_d method

### DIFF
--- a/lib/percentage.rb
+++ b/lib/percentage.rb
@@ -17,6 +17,10 @@ class Percentage
     (fractional_value * 100).to_f
   end
 
+  def to_d
+    BigDecimal(string_value)
+  end
+
   def to_s
     "#{string_value}%"
   end

--- a/percentage.gemspec
+++ b/percentage.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'percentage'
-  s.version = '1.0.0'
+  s.version = '1.0.1'
   s.license = 'LGPL-3.0'
   s.platform = Gem::Platform::RUBY
   s.authors = ['Tim Craft']

--- a/spec/percentage_spec.rb
+++ b/spec/percentage_spec.rb
@@ -49,6 +49,12 @@ describe 'Percentage object initialized with an integer value' do
     end
   end
 
+  describe 'to_d method' do
+    it 'returns the BigDecimal value of the percentage' do
+      @percentage.to_d.must_equal(BigDecimal("10.0"))
+    end
+  end
+
   describe 'to_s method' do
     it 'returns the integer value of the percentage suffixed with the percent symbol' do
       @percentage.to_s.must_equal('10%')


### PR DESCRIPTION
This fixes a problem with rails 4.2 number_to_\* helpers which call a to_d on the value passed (before it was possible to simply pass a Percentage to one of those helpers)
