### PR TITLE
BigDecimal helper methods #percent and #percent_of

### DIFF
--- a/lib/percentage.rb
+++ b/lib/percentage.rb
@@ -111,6 +111,14 @@ def Percentage.change(a, b)
 end
 
 class BigDecimal
+  def percent
+    Percentage(self)
+  end
+
+  def percent_of(n)
+    n * Percentage(self)
+  end
+
   def as_percentage_of(n)
     Percentage.new(self / n)
   end

--- a/spec/percentage_spec.rb
+++ b/spec/percentage_spec.rb
@@ -319,6 +319,23 @@ describe 'Percentage change method' do
   end
 end
 
+describe 'BigDecimal percent method' do
+  it 'returns a percentage object with the value of the decimal' do
+    percentage = BigDecimal(90).percent
+    percentage.must_be_instance_of(Percentage)
+    percentage.value.must_equal(BigDecimal('0.9'))
+  end
+end
+
+describe 'BigDecimal percent_of method' do
+  it 'returns the value of the receiver as a percentage multiplied by the argument' do
+    BigDecimal(90).percent_of(100).must_equal(90)
+    BigDecimal(90).percent_of(BigDecimal('15')).must_equal(BigDecimal('13.5'))
+    BigDecimal(90).percent_of(Rational(150, 2)).must_equal(Rational(135, 2))
+  end
+end
+
+
 describe 'BigDecimal as_percentage_of method' do
   it 'returns a percentage object with the value of the decimal divided by the argument' do
     percentage = BigDecimal('50.00').as_percentage_of(BigDecimal('100.00'))


### PR DESCRIPTION
These constructors treat the decimal as a percentage of 100.  Note that the internal representation is as a percentage of 1 (as can be seen in the spec on line 326).