### PR TITLE
Support ability to freeze Percentages by eagerly initializing object

### DIFF
--- a/lib/percentage.rb
+++ b/lib/percentage.rb
@@ -7,6 +7,7 @@ class Percentage
 
   def initialize(value)
     @value = value
+    @fractional_value = determine_fractional_value
   end
 
   def to_i
@@ -85,8 +86,10 @@ class Percentage
 
   protected
 
-  def fractional_value
-    @fractional_value ||= @value.integer? ? Rational(@value, 100) : @value
+  attr_reader :fractional_value
+
+  def determine_fractional_value
+    @value.integer? ? Rational(@value, 100) : @value
   end
 
   private

--- a/spec/percentage_spec.rb
+++ b/spec/percentage_spec.rb
@@ -24,6 +24,11 @@ describe 'Percentage object' do
 
     hash[Percentage.new(Rational(1, 10))].must_equal(3)
   end
+
+  it 'may be frozen' do
+    frozen = Percentage.new(10).freeze
+    frozen.to_f.must_equal(10)
+  end
 end
 
 describe 'Percentage object initialized with an integer value' do


### PR DESCRIPTION
# Problem

Since `Percentage` lazily calculates and memoizes its `fractional_value`, it doesn't play nicely when frozen.

```ruby
Percentage.new(10).freeze.to_i
=> FrozenError (can't modify frozen Percentage)
```

# Solution

Eagerly calculate and store this value upon initialization. I can't imagine this being a problem since Percentage values themselves are not publicly mutable objects and the calculation is relatively inexpensive.

Following that train of thought, it's also worth noting that there probably isn't a lot of value in freezing the instances anyway. Regardless I stumbled upon this while trying to replace an internal implementation of `Percentage` with the library and considering that the lib probably shouldn't actively resist frozen instances.

What do you think?