### PR TITLE
Add `bigdecimal` as a runtime dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,5 @@
 source 'https://rubygems.org'
 
+gemspec
 gem 'rspec-core', '~> 3'
 gem 'rspec-expectations', '~> 3'

--- a/percentage.gemspec
+++ b/percentage.gemspec
@@ -17,4 +17,5 @@ Gem::Specification.new do |s|
     'bug_tracker_uri' => 'https://github.com/readysteady/percentage/issues',
     'changelog_uri' => 'https://github.com/readysteady/percentage/blob/main/CHANGES.md'
   }
+  s.add_runtime_dependency 'bigdecimal'
 end


### PR DESCRIPTION
### Context

Percentage uses the `bigdecimal` library from the Ruby standard library:

https://github.com/readysteady/percentage/blob/272cdcc918c8c7b19092a0f36f4d1d4f0058a259/lib/percentage.rb#L1

In the forthcoming Ruby 3.4, the `bigdecimal` library will be come a 'bundled' library. It must be included in gem sets to be used with Bundler.

In [Ruby 3.3](https://www.ruby-lang.org/en/news/2023/12/25/ruby-3-3-0-released/) a deprecation warning is shown:

> lib/percentage.rb:1: warning: bigdecimal was loaded from the standard library, but will no longer be part of the default gems since Ruby 3.4.0. Add bigdecimal to your Gemfile or gemspec.

Example: https://github.com/readysteady/percentage/actions/runs/7491610080/job/20393213012#step:4:5

### Change

Add `bigdecimal` as a runtime dependency in the gemspec.